### PR TITLE
add px to top/bottom elements height

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,7 +68,7 @@ ViewList.prototype.render = function (data) {
   rows.unshift(this.html(this.childTagName, {
     className: 'top',
     style: {
-      height: this._displayStart * this.rowHeight,
+      height: this._displayStart * this.rowHeight + 'px',
       padding: 0,
       margin: 0
     }
@@ -78,7 +78,7 @@ ViewList.prototype.render = function (data) {
   rows.push(this.html(this.childTagName, {
     className: 'bottom',
     style: {
-      height: (data.length - this._displayEnd) * this.rowHeight,
+      height: (data.length - this._displayEnd) * this.rowHeight + 'px',
       padding: 0,
       margin: 0
     }


### PR DESCRIPTION
I encountered a bug where the scroll wasn't updating properly without this. I haven't yet figured out why in my situation this was necessary while in others it works without it.

Sidenote: here's the project: https://github.com/flatsheet/editdata.org 
I'm doing some experimenting with base-element in there.
